### PR TITLE
Run create function only once

### DIFF
--- a/collectd.run
+++ b/collectd.run
@@ -8,5 +8,5 @@ while true; do
   sleep 1
 done
 
-sh /create-20postgresql.conf.sh
+sh -x /create-20postgresql.conf.sh
 exec chpst -e /etc/service/collectd/env /usr/sbin/collectd -f

--- a/config/10postgresql-replication-queries.conf
+++ b/config/10postgresql-replication-queries.conf
@@ -6,7 +6,7 @@
   # replication lag in seconds (calculate on replica(s))
   <Query replication_lag>
     Statement "SELECT \
-    CASE WHEN NOT pg_is_in_recovery() THEN NULL \
+    CASE WHEN NOT pg_is_in_recovery() THEN -1 \
          WHEN pg_last_xlog_receive_location() = pg_last_xlog_replay_location() THEN 0 \
          ELSE EXTRACT (EPOCH FROM now() - pg_last_xact_replay_timestamp()) * 1000 \
     END AS replag;"
@@ -66,7 +66,11 @@
   </Query>
 
   <Query current_xlog_location>
-    Statement "SELECT pg_lsn_to_bytes(pg_current_xlog_location());"
+    Statement "SELECT \
+    CASE \
+      WHEN pg_is_in_recovery() THEN -1 \
+      ELSE pg_lsn_to_bytes(pg_current_xlog_location()) \
+    END AS pg_lsn_to_bytes;"
     <Result>
       Type gauge
       InstancePrefix current_xlog_location
@@ -75,7 +79,7 @@
   </Query>
 
   <Query last_xlog_receive_location>
-    Statement "SELECT pg_lsn_to_bytes(pg_last_xlog_receive_location());"
+    Statement "SELECT coalesce(pg_lsn_to_bytes(pg_last_xlog_receive_location()), -1) AS pg_lsn_to_bytes;"
     <Result>
       Type gauge
       InstancePrefix last_xlog_receive_location
@@ -84,7 +88,7 @@
   </Query>
 
   <Query last_xlog_replay_location>
-    Statement "SELECT pg_lsn_to_bytes(pg_last_xlog_replay_location());"
+    Statement "SELECT coalesce(pg_lsn_to_bytes(pg_last_xlog_replay_location()), -1) AS pg_lsn_to_bytes;"
     <Result>
       Type gauge
       InstancePrefix last_xlog_replay_location

--- a/config/10postgresql-replication-queries.conf
+++ b/config/10postgresql-replication-queries.conf
@@ -66,23 +66,7 @@
   </Query>
 
   <Query current_xlog_location>
-    Statement "CREATE OR REPLACE FUNCTION pg_lsn_to_bytes(lsn pg_lsn)
-        RETURNS bigint AS
-    $$
-    DECLARE
-        offset1 text;
-        xlog1 text;
-        result bigint;
-    BEGIN
-        xlog1=split_part($1::text,'/',1);
-        offset1=split_part($1::text,'/',2);
-        EXECUTE 'SELECT (x'''||'FF000000'||'''::bigint * x'''||xlog1||'''::bigint
-                                  + x'''||offset1||'''::bigint)' INTO result;
-        RETURN result;
-    END;
-    $$
-    LANGUAGE plpgsql IMMUTABLE STRICT;
-    SELECT pg_lsn_to_bytes(pg_current_xlog_location());"
+    Statement "SELECT pg_lsn_to_bytes(pg_current_xlog_location());"
     <Result>
       Type gauge
       InstancePrefix current_xlog_location

--- a/templates/create-20postgresql.conf.sh.tmpl
+++ b/templates/create-20postgresql.conf.sh.tmpl
@@ -3,6 +3,26 @@
 OUTPUT=/etc/collectd/collectd.conf.d/20postgresql.conf
 DBLIST_QUERY="SELECT datname FROM pg_database WHERE datistemplate = false AND datallowconn = true AND datname NOT IN ('postgres', 'rdsadmin');"
 
+PGFCT_QUERY="$(cat << EOF
+CREATE OR REPLACE FUNCTION pg_lsn_to_bytes(lsn pg_lsn)
+        RETURNS bigint AS
+    \$\$
+    DECLARE
+        offset1 text;
+        xlog1 text;
+        result bigint;
+    BEGIN
+        xlog1=split_part(\$1::text,'/',1);
+        offset1=split_part(\$1::text,'/',2);
+        EXECUTE 'SELECT (x'''||'FF000000'||'''::bigint * x'''||xlog1||'''::bigint
+                                  + x'''||offset1||'''::bigint)' INTO result;
+        RETURN result;
+    END;
+    \$\$
+    LANGUAGE plpgsql IMMUTABLE STRICT;
+EOF
+)"
+
 echo '<Plugin "postgresql">' > $OUTPUT
 
 {{ $containers := getvs "/containers/*/name" -}}
@@ -41,10 +61,15 @@ cat <<EOF >> $OUTPUT
 
 EOF
 
+export PGHOST="{{ $service }}.{{ $stack }}"
+export PGUSER="{{ $user }}"
+export PGDATABASE="template1"
 {{ if exists $password_path -}}
 export PGPASSWORD="{{ getv $password_path }}"
-{{ end }}
-echo $DBLIST_QUERY | psql -h {{ $service }}.{{ $stack }} -At -U{{ $user }} -d template1 | while read database; do
+{{ end -}}
+
+echo "$PGFCT_QUERY"  | psql
+echo "$DBLIST_QUERY" | psql -At | while read database; do
 
 cat <<EOF >> $OUTPUT
   <Database $database>
@@ -105,10 +130,15 @@ cat <<EOF >> $OUTPUT
 
 EOF
 
+export PGHOST="{{ $service }}.{{ $stack }}"
+export PGUSER="{{ $user }}"
+export PGDATABASE="template1"
 {{ if exists $password_path -}}
 export PGPASSWORD="{{ getv $password_path }}"
 {{ end -}}
-echo $DBLIST_QUERY | psql -h {{ $service }}.{{ $stack }} -At -U{{ $user }} -d template1 | while read database; do
+
+echo "$PGFCT_QUERY"  | psql
+echo "$DBLIST_QUERY" | psql -At | while read database; do
 
 cat <<EOF >> $OUTPUT
   <Database $database>


### PR DESCRIPTION
The goal here is mainly to avoid spamming the logs with errors.

Some of these statements return(ed) a NULL value, which collectd doesn't like. I made them return -1 instead. So dashboards might need to be adapted to take this in account.